### PR TITLE
ブロック一覧にある編集ボタンはタイトルの横ではなく、1つの列としてガタガタしないようにする、公開状態の表示。

### DIFF
--- a/View/BlogBlocks/index.ctp
+++ b/View/BlogBlocks/index.ctp
@@ -27,18 +27,17 @@
 			); ?>
 			<?php echo $this->BlockIndex->tableHeader(
 				'Block.name', __d('blogs', 'Blog Name'),
-				array('sort' => true)
+				array('sort' => true, 'editUrl' => true)
 			); ?>
 			<?php echo $this->BlockIndex->tableHeader(
 				'Blog.entries_count', __d('net_commons', 'Number'),
 				array('sort' => false)
 			); ?>
-			<?php // ε(　　　　 v ﾟωﾟ)　＜ 公開状態機能まち ?>
 			<?php
-			//echo $this->BlockIndex->tableHeader(
-			//	'Block.public_type', __d('blocks', 'Publishing setting'),
-			//	array('sort' => true)
-			//); ?>
+			echo $this->BlockIndex->tableHeader(
+				'Block.public_type', __d('blocks', 'Publishing setting'),
+				array('sort' => true)
+			); ?>
 			<?php echo $this->BlockIndex->tableHeader(
 				'TrackableUpdater.handlename', __d('net_commons', 'Modified user'),
 				array('sort' => true, 'type' => 'handle')
@@ -62,11 +61,9 @@
 			<?php echo $this->BlockIndex->tableData(
 				'Blog.entries_count', $blog['Blog']['entries_count']
 			); ?>
-			<?php // ε(　　　　 v ﾟωﾟ)　＜ 公開状態機能まち ?>
-			<?php
-			//echo $this->BlockIndex->tableData(
-			//	'Block.public_type', $blog['Block']['public_type']
-			//); ?>
+			<?php echo $this->BlockIndex->tableData(
+				'Block.public_type', $blog
+			); ?>
 			<?php echo $this->BlockIndex->tableData(
 				'TrackableUpdater', $blog,
 				array('type' => 'handle')
@@ -84,7 +81,7 @@
 
 		<?php echo $this->element('NetCommons.paginator'); ?>
 	</div>
-	
+
 
 </article>
 


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/261
