### PR TITLE
続きを書くのWYSIWYGの高さが小さいのでデフォルトの高さを設定するように修正

### DIFF
--- a/webroot/js/blogs_entry_edit.js
+++ b/webroot/js/blogs_entry_edit.js
@@ -9,7 +9,7 @@ NetCommonsApp.controller('Blogs',
          *
          * @type {object}
          */
-        $scope.tinymce = NetCommonsWysiwyg.new();
+        $scope.tinymce = NetCommonsWysiwyg.new({height: 280});
 
         $scope.writeBody2 = false;
 


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/541